### PR TITLE
Update depends and fix hex color formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
-/JavaApplication2/nbproject/private/
 /target
+
+# IntelliJ
+out/
+.idea/
+.idea_modules/
+*.iml
+*.ipr
+*.iws

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ MinecraftServerPing is very easy to use and implement into any project. Simply c
 
 ```java
 
-MinecraftPingOptions options = MinecraftPingOptions.builder()
+MCPingOptions options = MCPingOptions.builder()
   .hostname("example.com")
   .port(25565)
   .build();
 
-MinecraftPingReply data = MinecraftPing.getPing(options);      
-System.out.println(data.getDescription() + "  --  " + data.getPlayers().getOnline() + "/" + data.getPlayers().getMax());
+MCPingResponse data = MCPing.getPing(options);      
+System.out.println(data.getDescription().getStrippedText() + "  --  " + data.getPlayers().getOnline() + "/" + data.getPlayers().getMax());
 
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.azalim</groupId>
     <artifactId>mcserverping</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
     
     <name>MCServerPing</name>
@@ -26,7 +26,7 @@
     <repositories>
         <repository>
             <id>bungeecord-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/release</url>
         </repository>
     </repositories>
     
@@ -36,13 +36,13 @@
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
-            <version>3.3.1</version>
+            <version>3.4.0</version>
         </dependency>
         
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
+            <version>1.18.20</version>
             <scope>provided</scope>
         </dependency>
         
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-chat</artifactId>
-            <version>1.12-SNAPSHOT</version>
+            <version>1.16-R0.4</version>
             <type>jar</type>
         </dependency>
         

--- a/src/main/java/br/com/azalim/mcserverping/MCPingUtil.java
+++ b/src/main/java/br/com/azalim/mcserverping/MCPingUtil.java
@@ -42,7 +42,7 @@ public class MCPingUtil {
     public static final int STATUS_HANDSHAKE = 1;
 
     public static final char COLOR_CHAR = '\u00A7';
-    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + String.valueOf(COLOR_CHAR) + "[0-9A-FK-OR]");
+    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + COLOR_CHAR + "([0-9A-FK-OR]|#[0-9A-Fa-f]{3,6})");
 
     /**
      * Strips the given message of all color codes

--- a/src/main/java/br/com/azalim/mcserverping/examples/MCPingExample.java
+++ b/src/main/java/br/com/azalim/mcserverping/examples/MCPingExample.java
@@ -16,7 +16,7 @@ public class MCPingExample {
     public static void main(String[] args) {
 
         MCPingOptions options = MCPingOptions.builder()
-                .hostname("redesky.com")
+                .hostname("mc.hypixel.net")
                 .build();
 
         MCPingResponse reply;
@@ -29,21 +29,21 @@ public class MCPingExample {
         }
 
         System.out.println(String.format("Full response from %s:", options.getHostname()));
-        System.out.println("");
+        System.out.println();
 
         Description description = reply.getDescription();
 
         System.out.println("Description:");
         System.out.println("    Raw: " + description.getText());
         System.out.println("    No color codes: " + description.getStrippedText());
-        System.out.println("");
+        System.out.println();
 
         Players players = reply.getPlayers();
 
         System.out.println("Players: ");
         System.out.println("    Online count: " + players.getOnline());
         System.out.println("    Max players: " + players.getMax());
-        System.out.println("");
+        System.out.println();
 
         // Can be null depending on the server
         List<Player> sample = players.getSample();
@@ -53,7 +53,7 @@ public class MCPingExample {
                     .map(player -> String.format("%s@%s", player.getName(), player.getId()))
                     .collect(Collectors.joining(", "))
             );
-            System.out.println("");
+            System.out.println();
         }
 
         Version version = reply.getVersion();
@@ -63,7 +63,7 @@ public class MCPingExample {
         // The protocol is the version number: http://wiki.vg/Protocol_version_numbers
         System.out.println("    Protocol: " + version.getProtocol());
         System.out.println("    Name: " + version.getName());
-        System.out.println("");
+        System.out.println();
 
         System.out.println(String.format("Favicon: %s", reply.getFavicon()));
 

--- a/src/main/java/br/com/azalim/mcserverping/examples/MCPingExample.java
+++ b/src/main/java/br/com/azalim/mcserverping/examples/MCPingExample.java
@@ -16,7 +16,7 @@ public class MCPingExample {
     public static void main(String[] args) {
 
         MCPingOptions options = MCPingOptions.builder()
-                .hostname("mc.hypixel.net")
+                .hostname("redesky.com")
                 .build();
 
         MCPingResponse reply;


### PR DESCRIPTION
I also changed the example code to use `mc.hypixel.net` as its a well known server.

This fixes the below error
```
java.lang.IllegalArgumentException: No enum constant net.md_5.bungee.api.ChatColor.#E89F00
	at java.base/java.lang.Enum.valueOf(Enum.java:240)
	at net.md_5.bungee.api.ChatColor.valueOf(ChatColor.java:11)
	at net.md_5.bungee.chat.BaseComponentSerializer.deserialize(BaseComponentSerializer.java:23)
	at net.md_5.bungee.chat.TextComponentSerializer.deserialize(TextComponentSerializer.java:24)
	at net.md_5.bungee.chat.TextComponentSerializer.deserialize(TextComponentSerializer.java:16)
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
	at com.google.gson.Gson.fromJson(Gson.java:887)
	at com.google.gson.Gson.fromJson(Gson.java:952)
	at com.google.gson.internal.bind.TreeTypeAdapter$GsonContextImpl.deserialize(TreeTypeAdapter.java:162)
	at net.md_5.bungee.chat.ComponentSerializer.deserialize(ComponentSerializer.java:92)
	at net.md_5.bungee.chat.ComponentSerializer.deserialize(ComponentSerializer.java:21)
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41)
	at com.google.gson.internal.bind.ArrayTypeAdapter.read(ArrayTypeAdapter.java:72)
	at com.google.gson.Gson.fromJson(Gson.java:887)
	at com.google.gson.Gson.fromJson(Gson.java:952)
	at com.google.gson.Gson.fromJson(Gson.java:925)
	at net.md_5.bungee.chat.ComponentSerializer.parse(ComponentSerializer.java:42)
	at br.com.azalim.mcserverping.MCPing.getPing(MCPing.java:165)
```