### PR TITLE
Add option to specify protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Configuration is provided through the `MinecraftPingOptions` class. This class p
  * `int` port *(port of the server to query, **optional** default `25565`)*
  * `int` timeout *(socket timeout in ms, **optional** default `2000`)*
  * `String` charset *(charset for MOTD byte->string, **optional** default `UTF-8`)*
+ * `int` protocolVersion *(protocol version to ping the server with, **optional** default `4`)*
 
 ## Example
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.azalim</groupId>
     <artifactId>mcserverping</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <packaging>jar</packaging>
 
     <name>MCServerPing</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.azalim</groupId>
     <artifactId>mcserverping</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>jar</packaging>
-    
+
     <name>MCServerPing</name>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-    
+
     <distributionManagement>
         <repository>
             <id>github</id>
@@ -22,30 +22,30 @@
             <url>https://maven.pkg.github.com/lucaazalim/minecraft-server-ping</url>
         </repository>
     </distributionManagement>
-    
+
     <repositories>
         <repository>
             <id>bungeecord-repo</id>
             <url>https://oss.sonatype.org/content/repositories/release</url>
         </repository>
     </repositories>
-    
+
     <dependencies>
-        
+
         <!-- Needed to resolve SRV records-->
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
             <version>3.4.0</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.20</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- Needed to access the TextComponent API -->
         <dependency>
             <groupId>net.md-5</groupId>
@@ -53,6 +53,6 @@
             <version>1.16-R0.4</version>
             <type>jar</type>
         </dependency>
-        
+
     </dependencies>
 </project>

--- a/src/main/java/br/com/azalim/mcserverping/MCPing.java
+++ b/src/main/java/br/com/azalim/mcserverping/MCPing.java
@@ -110,7 +110,7 @@ public class MCPing {
                  DataOutputStream handshake = new DataOutputStream(handshake_bytes)) {
 
                 handshake.writeByte(MCPingUtil.PACKET_HANDSHAKE);
-                MCPingUtil.writeVarInt(handshake, MCPingUtil.PROTOCOL_VERSION);
+                MCPingUtil.writeVarInt(handshake, options.getProtocolVersion());
                 MCPingUtil.writeVarInt(handshake, options.getHostname().length());
                 handshake.writeBytes(options.getHostname());
                 handshake.writeShort(options.getPort());

--- a/src/main/java/br/com/azalim/mcserverping/MCPingOptions.java
+++ b/src/main/java/br/com/azalim/mcserverping/MCPingOptions.java
@@ -53,4 +53,8 @@ public class MCPingOptions {
     @Builder.Default
     private int timeout = 5000;
 
+    @Getter
+    @Builder.Default
+    private int protocolVersion = 4;
+
 }

--- a/src/main/java/br/com/azalim/mcserverping/MCPingUtil.java
+++ b/src/main/java/br/com/azalim/mcserverping/MCPingUtil.java
@@ -38,11 +38,10 @@ public class MCPingUtil {
     public static final byte PACKET_HANDSHAKE = 0x00,
             PACKET_STATUSREQUEST = 0x00,
             PACKET_PING = 0x01;
-    public static final int PROTOCOL_VERSION = 4;
     public static final int STATUS_HANDSHAKE = 1;
 
     public static final char COLOR_CHAR = '\u00A7';
-    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + COLOR_CHAR + "([0-9A-FK-OR]|#[0-9A-Fa-f]{3,6})");
+    private static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + COLOR_CHAR + "([0-9A-FK-ORX]|#[0-9A-Fa-f]{3,6})");
 
     /**
      * Strips the given message of all color codes


### PR DESCRIPTION
Currently the protocol version is hardcoded to version 4. A lot of Bukkit servers will conditionally send different MOTDs to different versions of Minecraft depending on what protocol was sent. 

This PR gives people the opportunity to select what protocol version they want to ping the server with. The value still defaults to 4, so no changes made should break any existing code.

I have also added x to the regex for stripping text. This ensures that `§x` won't show up if people use stripped text when people ping a server that happens to have a hex MOTD.