### PR TITLE
Updated all dependencies to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <repositories>
         <repository>
             <id>bungeecord-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/release</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
     </repositories>
 
@@ -36,23 +36,30 @@
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.2</version>
         </dependency>
 
+        <!-- Needed for MCPingOptions & MCPingResponse Annotations -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.26</version>
             <scope>provided</scope>
         </dependency>
 
         <!-- Needed to access the TextComponent API -->
         <dependency>
             <groupId>net.md-5</groupId>
-            <artifactId>bungeecord-chat</artifactId>
-            <version>1.16-R0.4</version>
+            <artifactId>bungeecord-api</artifactId>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
 
+        <!-- Needed to handle Json in MCPing methods -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
- Gson is now included as dependency as we now use bungeecord-api instead of bungeecord-chat which used to contain gson as a dependency