### PR TITLE
Add socket read timeout

### DIFF
--- a/src/main/java/br/com/azalim/mcserverping/MCPing.java
+++ b/src/main/java/br/com/azalim/mcserverping/MCPing.java
@@ -99,6 +99,7 @@ public class MCPing {
 
         try (final Socket socket = new Socket()) {
 
+            socket.setSoTimeout(options.getReadTimeout());
             long start = System.currentTimeMillis();
             socket.connect(new InetSocketAddress(hostname, port), options.getTimeout());
             ping = System.currentTimeMillis() - start;

--- a/src/main/java/br/com/azalim/mcserverping/MCPingOptions.java
+++ b/src/main/java/br/com/azalim/mcserverping/MCPingOptions.java
@@ -55,6 +55,10 @@ public class MCPingOptions {
 
     @Getter
     @Builder.Default
+    private int readTimeout = 5000;
+
+    @Getter
+    @Builder.Default
     private int protocolVersion = 4;
 
 }


### PR DESCRIPTION
Adds an option to customize the timeout in socket `read()` calls, defaults to 5 seconds. Servers that connect but stop sending data early will no longer cause `getPing()` to block forever.